### PR TITLE
Use ProxyResponseHandler to preserve original/edited history

### DIFF
--- a/src/main/java/Extension.java
+++ b/src/main/java/Extension.java
@@ -24,5 +24,8 @@ public class Extension implements BurpExtension {
 
     api.proxy().registerRequestHandler(
         new ProxyHttpRequestHandler(api, tab));
+ 
+    api.proxy().registerResponseHandler(
+        new ProxyHttpResponseHandler(api, tab));
   }
 }

--- a/src/main/java/MyHttpHandler.java
+++ b/src/main/java/MyHttpHandler.java
@@ -77,6 +77,11 @@ class MyHttpHandler implements HttpHandler {
   public ResponseReceivedAction handleHttpResponseReceived(
       HttpResponseReceived responseReceived
   ) {
+
+    if (responseReceived.toolSource().isFromTool(ToolType.PROXY)) {
+      return continueWith(responseReceived, responseReceived.annotations());
+    }
+
     String url = Utils.removeQueryFromUrl(
         responseReceived.initiatingRequest().url());
     HashMap<String, PersistedList<String>> scope =

--- a/src/main/java/ProxyHttpResponseHandler.java
+++ b/src/main/java/ProxyHttpResponseHandler.java
@@ -1,0 +1,86 @@
+import burp.api.montoya.MontoyaApi;
+import burp.api.montoya.core.Annotations;
+import burp.api.montoya.http.message.responses.HttpResponse;
+import burp.api.montoya.persistence.PersistedList;
+import burp.api.montoya.proxy.http.InterceptedResponse;
+import burp.api.montoya.proxy.http.ProxyResponseHandler;
+import burp.api.montoya.proxy.http.ProxyResponseReceivedAction;
+import burp.api.montoya.proxy.http.ProxyResponseToBeSentAction;
+import models.ExecutorOutput;
+
+import java.util.HashMap;
+
+class ProxyHttpResponseHandler implements ProxyResponseHandler {
+  MontoyaApi api;
+  MainTab mainTab;
+
+  public ProxyHttpResponseHandler(MontoyaApi api, MainTab tab) {
+    this.api = api;
+    this.mainTab = tab;
+  }
+
+  @Override
+  public ProxyResponseReceivedAction handleResponseReceived(
+      InterceptedResponse interceptedResponse
+  ) {
+    String url = Utils.removeQueryFromUrl(interceptedResponse.initiatingRequest().url());
+    HashMap<String, PersistedList<String>> scope =
+        Utils.loadScope(api.persistence().extensionData());
+
+    HttpResponse response = interceptedResponse
+        .withStatusCode(interceptedResponse.statusCode());
+
+    Annotations annotations = interceptedResponse.annotations();
+
+    boolean isUrlInScope = Utils.isUrlInScope(url, scope.get("scope"));
+
+    if (this.mainTab.responseCheckBox.isSelected() && isUrlInScope) {
+      HashMap<String, String> preparedToExecute = Utils.prepareResponseForExecutor(
+          interceptedResponse,
+          url,
+          interceptedResponse.messageId(),
+          "proxy"
+      );
+
+      ExecutorOutput executorOutput = Executor.execute(
+          api, "decrypt", "response", preparedToExecute);
+
+      HttpResponse decryptedResponse =
+          Utils.executorToHttpResponse(interceptedResponse, executorOutput);
+
+      if (executorOutput.issue != null) {
+        Utils.setIssue(
+            api,
+            executorOutput.issue,
+            url,
+            interceptedResponse.initiatingRequest(),
+            interceptedResponse
+        );
+      }
+
+      if (executorOutput.annotation != null) {
+        annotations = Utils.setAnnotation(
+            annotations.notes(),
+            executorOutput.annotation.get("color"),
+            executorOutput.annotation.get("note")
+        );
+      }
+
+      return ProxyResponseReceivedAction.continueWith(decryptedResponse, annotations);
+    }
+
+    if (isUrlInScope) {
+      response = response
+          .withAddedHeader(Constants.STRIPPER_HEADER, Constants.X_STRIPPER_RESPONSE_NOT_SELECTED);
+    }
+
+    return ProxyResponseReceivedAction.continueWith(response, annotations);
+  }
+
+  @Override
+  public ProxyResponseToBeSentAction handleResponseToBeSent(
+      InterceptedResponse interceptedResponse
+  ) {
+    return ProxyResponseToBeSentAction.continueWith(interceptedResponse);
+  }
+}


### PR DESCRIPTION
Moved response transformation to the proxy flow with a new handler and skipped the proxy source in the current handler to avoid duplicate processing, in this way Burp can show the original and edited response in proxy history.